### PR TITLE
add info about "data" method to json deprecation annotation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -706,6 +706,7 @@
 - willhack
 - willin
 - willowcheng
+- willsmithte
 - wizardlyhel
 - wKovacs64
 - wladiston

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -50,7 +50,6 @@ export type TypedResponse<T = unknown> = Omit<Response, "json"> & {
  * 
  * If you need to return a JSON Response from a resource route, you can use 
  * `Response.json` (https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static).
- * 
  *
  * @see https://remix.run/utils/json
  */

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -43,8 +43,14 @@ export type TypedResponse<T = unknown> = Omit<Response, "json"> & {
  *
  * @deprecated This utility is deprecated in favor of opting into Single Fetch
  * via `future.v3_singleFetch` and returning raw objects.  This method will be
- * removed in React Router v7.  If you need to return a JSON Response, you can
- * use `Response.json()`. If you need to add headers or status codes, use `data()`: https://remix.run/docs/en/main/utils/data
+ * removed in React Router v7.
+ * 
+ * If you need to return custom headers or status code, you can use the new `data`
+ * utility, see: (https://remix.run/docs/en/main/utils/data).
+ * 
+ * If you need to return a JSON Response from a resource route, you can use 
+ * `Response.json`, see: https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static
+ * 
  *
  * @see https://remix.run/utils/json
  */

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -44,7 +44,7 @@ export type TypedResponse<T = unknown> = Omit<Response, "json"> & {
  * @deprecated This utility is deprecated in favor of opting into Single Fetch
  * via `future.v3_singleFetch` and returning raw objects.  This method will be
  * removed in React Router v7.  If you need to return a JSON Response, you can
- * use `Response.json()`.
+ * use `Response.json()`. If you need to add headers or status codes, use `data()`: https://remix.run/docs/en/main/utils/data
  *
  * @see https://remix.run/utils/json
  */

--- a/packages/remix-server-runtime/responses.ts
+++ b/packages/remix-server-runtime/responses.ts
@@ -46,10 +46,10 @@ export type TypedResponse<T = unknown> = Omit<Response, "json"> & {
  * removed in React Router v7.
  * 
  * If you need to return custom headers or status code, you can use the new `data`
- * utility, see: (https://remix.run/docs/en/main/utils/data).
+ * utility (https://remix.run/docs/en/main/utils/data).
  * 
  * If you need to return a JSON Response from a resource route, you can use 
- * `Response.json`, see: https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static
+ * `Response.json` (https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static).
  * 
  *
  * @see https://remix.run/utils/json


### PR DESCRIPTION

- [ x] Docs
- [ ] Tests

I don't think this is the best way to write it, but it was difficult for me to find the equivalent of `json`, and I'd already opted into single fetch so needed to remove `json` to get the turbostream deserialization (keep `Date` typing). I think we should add info about `data` to the deprecation notice.

Similar issue: https://github.com/remix-run/remix/discussions/10233